### PR TITLE
No symbolic icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This manifest allows Transmission access to:
 
 * `com.transmissionbt.Transmission.appdata.xml`: [accepted upstream](https://github.com/transmission/transmission/pull/224) but not yet part of a release.
 * `0001-gtk-use-com.transmissionbt.Transmission.-D-Bus-names.patch`: Flatpak only allows apps to own names within the namespace matching the app name. Not submitted upstream.
+* `gtk-add-symbolic-icon.patch`: [submitted upstream](https://github.com/transmission/transmission/pull/449).
 
 ## Colophon
 

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -61,6 +61,10 @@
                     "path": "0001-gtk-use-com.transmissionbt.Transmission.-D-Bus-names.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "gtk-add-symbolic-icon.patch"
+                },
+                {
                     "type": "shell",
                     "commands": [
                         "rm m4/glib-gettext.m4"

--- a/gtk-add-symbolic-icon.patch
+++ b/gtk-add-symbolic-icon.patch
@@ -1,0 +1,106 @@
+From 01ffcd5dcfd69e2a88604097ffa90bdea306a3af Mon Sep 17 00:00:00 2001
+From: Will Thompson <will@willthompson.co.uk>
+Date: Thu, 30 Nov 2017 16:41:39 +0000
+Subject: [PATCH] gtk: add symbolic icon
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The -symbolic icon variant (if available) is used in the GNOME top bar,
+and when the high contrast theme is in use.  This icon was created by
+Jakub Steiner, and comes from the gnome-icons repository:
+
+https://github.com/gnome-design-team/gnome-icons/blob/master/apps-symbolic/Adwaita/scalable/apps/transmission-symbolic.svg
+https://bugzilla.redhat.com/show_bug.cgi?id=1221292
+
+There is some confusion over whether symbolic app icons should be
+installed to icons/hicolor/scalable/apps (alongside the regular scalable
+icon) or to icons/hicolor/symbolic/apps. On the one hand,
+https://wiki.gnome.org/Initiatives/GnomeGoals/HighContrastAppIcons has
+this to say:
+
+> […] obtain a suitable symbolic style icon […] and install it to the
+> hicolor prefix, the same way you would for the full color variant.
+>
+> cp myapp-symbolic.svg /usr/share/icons/hicolor/scalable/apps/myapp-symbolic.svg
+
+On the other hand, the Fedora package at
+https://src.fedoraproject.org/rpms/transmission/blob/master/f/transmission.spec
+ships this icon in icons/hicolor/symbolic/apps:
+
+> # Install the symbolic icon
+> mkdir -p  %{buildroot}%{_datadir}/icons/hicolor/symbolic/apps
+> cp %{SOURCE1} %{buildroot}%{_datadir}/icons/hicolor/symbolic/apps/transmission-symbolic.svg
+
+Anecdotally, icons in scalable/ have minimum size 64×64 on openSUSE, so
+symbolic/ is the safer location (given the GNOME top bar uses 32×32
+icons). This has the advantage of matching the location used in the
+distribution which already ships this file.
+
+https://github.com/transmission/transmission/issues/414
+---
+ gtk/CMakeLists.txt                                 |  1 +
+ gtk/icons/Makefile.am                              |  1 +
+ ...hicolor_apps_symbolic_transmission-symbolic.svg | 26 ++++++++++++++++++++++
+ 3 files changed, 28 insertions(+)
+ create mode 100644 gtk/icons/hicolor_apps_symbolic_transmission-symbolic.svg
+
+diff --git a/gtk/CMakeLists.txt b/gtk/CMakeLists.txt
+index f4193d6b5..18091c01b 100644
+--- a/gtk/CMakeLists.txt
++++ b/gtk/CMakeLists.txt
+@@ -183,6 +183,7 @@ set(${PROJECT_NAME}_PUBLIC_ICONS
+     hicolor_apps_48x48_transmission.png
+     hicolor_apps_256x256_transmission.png
+     hicolor_apps_scalable_transmission.svg
++    hicolor_apps_symbolic_transmission-symbolic.svg
+ )
+ 
+ set(ICON_NAME_REGEX "^([^_]+)_([^_]+)_([^_]+)_(.+)$")
+diff --git a/gtk/icons/Makefile.am b/gtk/icons/Makefile.am
+index 989d69394..88f784c52 100644
+--- a/gtk/icons/Makefile.am
++++ b/gtk/icons/Makefile.am
+@@ -12,6 +12,7 @@ public_icons = \
+ 	hicolor_apps_48x48_transmission.png \
+ 	hicolor_apps_256x256_transmission.png \
+ 	hicolor_apps_scalable_transmission.svg \
++	hicolor_apps_symbolic_transmission-symbolic.svg \
+ 	$(NULL)
+ 
+ private_icons = \
+diff --git a/gtk/icons/hicolor_apps_symbolic_transmission-symbolic.svg b/gtk/icons/hicolor_apps_symbolic_transmission-symbolic.svg
+new file mode 100644
+index 000000000..474dec021
+--- /dev/null
++++ b/gtk/icons/hicolor_apps_symbolic_transmission-symbolic.svg
+@@ -0,0 +1,26 @@
++<?xml version='1.0' encoding='UTF-8' standalone='no'?>
++<!-- Created with Inkscape (http://www.inkscape.org/) -->
++
++<svg xmlns:cc='http://creativecommons.org/ns#' xmlns:dc='http://purl.org/dc/elements/1.1/' sodipodi:docname='transmission-symbolic.svg' height='16' id='svg7384' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape' xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' xmlns:sodipodi='http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd' xmlns:svg='http://www.w3.org/2000/svg' inkscape:version='0.48.2 r9819' version='1.1' width='16.000015' xmlns='http://www.w3.org/2000/svg'>
++  <metadata id='metadata90'>
++    <rdf:RDF>
++      <cc:Work rdf:about=''>
++        <dc:format>image/svg+xml</dc:format>
++        <dc:type rdf:resource='http://purl.org/dc/dcmitype/StillImage'/>
++        <dc:title>Gnome Symbolic Icon Theme</dc:title>
++      </cc:Work>
++    </rdf:RDF>
++  </metadata>
++  <sodipodi:namedview inkscape:bbox-paths='true' bordercolor='#666666' borderopacity='1' inkscape:current-layer='layer9' inkscape:cx='30.54833' inkscape:cy='8.54942' gridtolerance='10' inkscape:guide-bbox='true' guidetolerance='10' id='namedview88' inkscape:object-nodes='false' inkscape:object-paths='false' objecttolerance='10' pagecolor='#555753' inkscape:pageopacity='1' inkscape:pageshadow='2' showborder='false' showgrid='true' showguides='true' inkscape:snap-bbox='false' inkscape:snap-bbox-midpoints='false' inkscape:snap-global='true' inkscape:snap-grids='true' inkscape:snap-nodes='true' inkscape:snap-others='false' inkscape:snap-to-guides='true' inkscape:window-height='1381' inkscape:window-maximized='1' inkscape:window-width='2560' inkscape:window-x='1600' inkscape:window-y='27' inkscape:zoom='32'>
++    <inkscape:grid empspacing='2' enabled='true' id='grid4866' snapvisiblegridlinesonly='true' spacingx='1px' spacingy='1px' type='xygrid' visible='true'/>
++  </sodipodi:namedview>
++  <title id='title9167'>Gnome Symbolic Icon Theme</title>
++  <defs id='defs7386'/>
++  <g inkscape:groupmode='layer' id='layer9' inkscape:label='apps' style='display:inline' transform='translate(-43.0002,-215)'>
++    
++    <path inkscape:connector-curvature='0' d='m 46.420162,221 c -0.60874,0 -1.56297,0.0246 -1.98514,2 l -1.3958,6.53125 c -0.12417,0.58106 0,1.46875 1.08563,1.46875 l 13.70981,0 c 1.08562,0 1.2142,-0.98241 1.08562,-1.5625 L 57.493462,223 c -0.42669,-1.92518 -1.37639,-2 -1.98513,-2 l -1.55088,0 0,1 c 0.5273,0 -1.70779,0 0.99256,0 0.99257,0 1.06291,1.30944 1.42682,3 l 0.55831,2.59375 c 0.1639,0.76136 0,1.40625 -1.39579,1.40625 l -9.05716,0 c -1.45783,0 -1.53332,-0.63961 -1.3958,-1.40625 L 45.551662,225 c 0.32106,-1.78985 0.46527,-3 1.45783,-3 l 0.99257,0 0,-1 z' id='rect5849' sodipodi:nodetypes='ssssssssccssssssssccs' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate'/>
++    <path inkscape:connector-curvature='0' d='m 47.009492,224 7.94052,0 -3.95778,4 z' id='rect6273' sodipodi:nodetypes='cccc' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter4896-5-0-6-4-8-7-6);enable-background:accumulate'/>
++    <rect height='7' id='rect5226-91-0-6' rx='0' ry='0' style='color:#000000;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00000012;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new' width='3.9702628' x='48.994617' y='216'/>
++    <rect height='2' id='rect14612' rx='0.99256569' ry='2' style='fill:#bebebe;fill-opacity:1;stroke:none' width='9.9256573' x='46.016933' y='216'/>
++  </g>
++</svg>
+-- 
+2.14.2
+


### PR DESCRIPTION
Reported at https://github.com/transmission/transmission/issues/414 by @Obsidien.

In fact, the symbolic icon is not included in the upstream package. It's added by [Fedora's packaging](https://src.fedoraproject.org/rpms/transmission/tree/master) for example. In the short term we can include the icon here, too, but we should try to upstream this!