### PR TITLE
manifest: allow talking to gvfs daemon

### DIFF
--- a/com.transmissionbt.Transmission.appdata.xml
+++ b/com.transmissionbt.Transmission.appdata.xml
@@ -151,4 +151,11 @@
       <image type="source">https://raw.githubusercontent.com/transmission/transmission/master/gtk/screenshots/a.png</image>
     </screenshot>
   </screenshots>
+  <releases>
+    <release date="2017-12-13" version="2.92-3">
+      <description>
+        <p>Fix File → Open URI.</p>
+      </description>
+    </release>
+  </releases>
 </component>

--- a/com.transmissionbt.Transmission.appdata.xml
+++ b/com.transmissionbt.Transmission.appdata.xml
@@ -158,4 +158,6 @@
       </description>
     </release>
   </releases>
+  <translation type="gettext">transmission-gtk</translation>
+  <update_contact>will+transmission@willthompson.co.uk</update_contact>
 </component>

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -18,7 +18,10 @@
         "--filesystem=host",
 
         "--talk-name=ca.desrt.dconf",
-        "--talk-name=org.freedesktop.Notifications"
+        "--talk-name=org.freedesktop.Notifications",
+
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*"
     ],
     "cleanup": [
         "*.a",


### PR DESCRIPTION
This fixes File → Open URL…, which is implemented with
g_file_new_for_uri(), which in turn uses GVFS for http[s]:// URIs.