### PR TITLE
Remove daemon and other unused binaries

### DIFF
--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -51,8 +51,7 @@
               "/bin/transmission-create",
               "/bin/transmission-daemon",
               "/bin/transmission-edit",
-              "/bin/transmission-show",
-              "/share/transmission"
+              "/bin/transmission-show"
             ],
             "sources": [
                 {

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -47,6 +47,13 @@
         },
         {
             "name": "transmission",
+            "cleanup": [
+              "/bin/transmission-create",
+              "/bin/transmission-daemon",
+              "/bin/transmission-edit",
+              "/bin/transmission-show",
+              "/share/transmission"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
 -remote was kept as it may be useful and is small.

Note that `--disable-daemon` wasn't used since it remvoes -remote
~~and leaves all of the web data anyway (which should be fixed upstream)~~