### PR TITLE
Update runtime to 3.38

### DIFF
--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.transmissionbt.Transmission",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.36",
+    "runtime-version": "3.38",
     "sdk": "org.gnome.Sdk",
     "command": "transmission-gtk",
     "rename-desktop-file": "transmission-gtk.desktop",
@@ -43,8 +43,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libevent/libevent/releases/download/release-2.1.11-stable/libevent-2.1.11-stable.tar.gz",
-                    "sha256": "a65bac6202ea8c5609fd5c7e480e6d25de467ea1917c08290c521752f147283d"
+                    "url": "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz",
+                    "sha256": "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
                 }
             ]
         },


### PR DESCRIPTION
With this update, libevent was updated as well to the latest 2.1.12 stable release.

The 'libcanberra' warnings received when starting the app after this update happen because that package was removed from the 3.38 Gnome platform (it was no longer maintained). From my testing, they don't affect the functionality of the program.