### PR TITLE
Add flatpak-external-data-checker integration; update to GNOME 41 runtime

### DIFF
--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -60,7 +60,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/transmission/transmission-releases/raw/master/transmission-3.00.tar.xz",
+                    "url": "https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00.tar.xz",
                     "sha256": "9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2"
                 },
                 {

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -11,19 +11,14 @@
     "finish-args": [
         "--share=ipc",
         "--share=network",
-
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-
         "--filesystem=host",
-
         "--talk-name=org.freedesktop.Notifications",
-
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*",
-
         "--talk-name=org.kde.StatusNotifierWatcher"
     ],
     "cleanup": [
@@ -38,8 +33,8 @@
         {
             "name": "libevent",
             "cleanup": [
-              "/include",
-              "/bin"
+                "/include",
+                "/bin"
             ],
             "sources": [
                 {
@@ -52,10 +47,10 @@
         {
             "name": "transmission",
             "cleanup": [
-              "/bin/transmission-create",
-              "/bin/transmission-daemon",
-              "/bin/transmission-edit",
-              "/bin/transmission-show"
+                "/bin/transmission-create",
+                "/bin/transmission-daemon",
+                "/bin/transmission-edit",
+                "/bin/transmission-show"
             ],
             "sources": [
                 {

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -38,6 +38,11 @@
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1606,
+                        "url-template": "https://github.com/libevent/libevent/releases/download/release-$version-stable/libevent-$version-stable.tar.gz"
+                    },
                     "type": "archive",
                     "url": "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz",
                     "sha256": "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
@@ -54,6 +59,11 @@
             ],
             "sources": [
                 {
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 5002,
+                        "url-template": "https://github.com/transmission/transmission/releases/download/$version/transmission-$version.tar.xz"
+                    },
                     "type": "archive",
                     "url": "https://github.com/transmission/transmission/releases/download/3.00/transmission-3.00.tar.xz",
                     "sha256": "9144652fe742f7f7dd6657716e378da60b751aaeda8bef8344b3eefc4db255f2"

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.transmissionbt.Transmission",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "transmission-gtk",
     "rename-desktop-file": "transmission-gtk.desktop",


### PR DESCRIPTION
Rumour has it that the frequency of Transmission releases may increase. Let's automate this side of it.

Fixes #39.
