### PR TITLE
Revert "Bump the runtime to 43"

### DIFF
--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.transmissionbt.Transmission",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "command": "transmission-gtk",
     "rename-desktop-file": "transmission-gtk.desktop",


### PR DESCRIPTION
This reverts commit 2dbec8491ccb259968811eac0daafebac8b6995f. Turns out there is some incompatibility between Transmission and OpenSSL 3.x.

https://github.com/flathub/com.transmissionbt.Transmission/pull/45#issuecomment-1298853140 https://github.com/flathub/com.transmissionbt.Transmission/issues/46