### PR TITLE
Add libcanberra

### DIFF
--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -179,6 +179,45 @@
             ]
         },
         {
+            "name": "canberra",
+            "cleanup": [
+                "/etc",
+                "/include",
+                "/lib/gnome-settings-daemon-3.0",
+                "/lib/gtk-3.0",
+                "/libexec",
+                "/share/gtk-doc",
+                "/share/vala"
+            ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-gtk-doc",
+                "--disable-oss",
+                "--enable-pulse",
+                "--disable-udev",
+                "--disable-gtk",
+                "--enable-gtk3",
+                "--disable-lynx"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+                    "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+                }
+            ]
+        },
+        {
+            "name": "sound-theme-freedesktop",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-0.8.tar.bz2",
+                    "sha256": "cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14"
+                }
+            ]
+        },
+        {
             "name": "transmission",
             "buildsystem": "cmake-ninja",
             "config-opts": [


### PR DESCRIPTION
Transmission by default uses `canberra-gtk-play` to play the torrent finished sound, the default sound is `complete.oga` from sound-theme-freedesktop which is not included in the runtime.

Hopefully resolves https://github.com/flathub/com.transmissionbt.Transmission/issues/37

This is taken from the shared-module (but that cleans up `/bin`)