### PR TITLE
Allow talking to org.gnome.SessionManager on the session bus

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This manifest allows Transmission access to:
 * Notifications, to show a bubble when a transfer is complete
 * GVFS, to support opening torrent files by URI
 * `org.kde.StatusNotifierWatcher`, to display a notification area icon in environments where this is supported
+* `org.gnome.SessionManager`, to inhibit suspend / hibernation while there are active uploads or downloads
 
 ## Delta from upstream
 

--- a/com.transmissionbt.Transmission.json
+++ b/com.transmissionbt.Transmission.json
@@ -19,7 +19,8 @@
         "--talk-name=org.freedesktop.Notifications",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.gnome.SessionManager"
     ],
     "cleanup": [
         "*.a",


### PR DESCRIPTION
This allows the "inhibit-desktop-hibernation" option to work.